### PR TITLE
feat: Extend support for XRANGE command for queries with '-' or '+'

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -658,18 +658,31 @@ func handleXRange(args []string, conn net.Conn) {
 		return
 	}
 
-	// normalize the start and end IDs (add sequence numbers if missing)
-	startID = normalizeEntryID(startID, false)
+	// handle special case for "-" start ID
+	useMinStart := (startID == "-")
+	
+	// normalize the start and end IDs to add sequence numbers if missing
+	if !useMinStart {
+		startID = normalizeEntryID(startID, false)
+	}
 	endID = normalizeEntryID(endID, true)
 
 	// find entries within the range
 	var result []StreamEntryData
 	for _, entry := range streamEntry.entries {
 		// check if entry is within range
-		startComp, err := compareEntryIDs(entry.id, startID)
-		if err != nil {
-			writeError(conn, "invalid start entry ID format")
-			return
+		var startComp int
+		var err error
+		
+		if useMinStart {
+			// when start is "-", all entries satisfy the start condition
+			startComp = 1 // entry.id >= start (since start is effectively minimum)
+		} else {
+			startComp, err = compareEntryIDs(entry.id, startID)
+			if err != nil {
+				writeError(conn, "invalid start entry ID format")
+				return
+			}
 		}
 
 		endComp, err := compareEntryIDs(entry.id, endID)

--- a/app/commands.go
+++ b/app/commands.go
@@ -661,11 +661,16 @@ func handleXRange(args []string, conn net.Conn) {
 	// handle special case for "-" start ID
 	useMinStart := (startID == "-")
 	
+	// handle special case for "+" end ID
+	useMaxEnd := (endID == "+")
+	
 	// normalize the start and end IDs to add sequence numbers if missing
 	if !useMinStart {
 		startID = normalizeEntryID(startID, false)
 	}
-	endID = normalizeEntryID(endID, true)
+	if !useMaxEnd {
+		endID = normalizeEntryID(endID, true)
+	}
 
 	// find entries within the range
 	var result []StreamEntryData
@@ -686,9 +691,14 @@ func handleXRange(args []string, conn net.Conn) {
 		}
 
 		endComp, err := compareEntryIDs(entry.id, endID)
-		if err != nil {
+		if err != nil && !useMaxEnd {
 			writeError(conn, "invalid end entry ID format")
 			return
+		}
+
+		// when using "+", all entries satisfy the end condition
+		if useMaxEnd {
+			endComp = -1 // entry.id <= end (since end is effectively maximum)
 		}
 
 		// include entry if: entry.id >= startID AND entry.id <= endID

--- a/app/database.go
+++ b/app/database.go
@@ -60,8 +60,8 @@ func blockClient(conn net.Conn, listKey string, timeout float64) {
 			case <-client.done:
 				// element became available
 			case <-time.After(timeoutDuration):
-				// timeout reached, send null response
-				writeNullBulkString(conn)
+				// timeout reached, send null array response
+				writeNullArray(conn)
 			}
 		}
 	}()

--- a/app/resp.go
+++ b/app/resp.go
@@ -23,6 +23,11 @@ func writeNullBulkString(conn net.Conn) error {
 	return err
 }
 
+func writeNullArray(conn net.Conn) error {
+	_, err := conn.Write([]byte("*-1\r\n"))
+	return err
+}
+
 func writeInteger(conn net.Conn, val int) error {
 	_, err := conn.Write([]byte(fmt.Sprintf(":%d\r\n", val)))
 	return err


### PR DESCRIPTION
This PR introduces improved handling of special range queries and response formats in the stream and blocking list commands, resulting in more robust and standards-compliant behavior.

**Stream range query improvements:**

* Updated the `handleXRange` function in `app/commands.go` to correctly handle special start (`"-"`) and end (`"+"`) IDs in range queries, ensuring that queries using these values return all entries from the minimum or up to the maximum, respectively.

**Blocking list response consistency:**

* Modified the blocking list operation in `blockClient` (`app/database.go`) to send a null array response (`*-1\r\n`) instead of a null bulk string when a timeout occurs, aligning with RESP protocol expectations for list operations.
* Added a new helper function `writeNullArray` to `app/resp.go` to support sending null array responses over the connection.