### PR TITLE
feat: Implements Redis streams in RegoDB

### DIFF
--- a/app/commands.go
+++ b/app/commands.go
@@ -788,8 +788,14 @@ func handleXRead(args []string, conn net.Conn) {
 		return
 	}
 
-	// no results and blocking requested - block the client
-	blockXReadClient(conn, streamKeys, streamIDs, blockTimeout)
+	// no results and blocking requested - resolve $ IDs before blocking
+	resolvedStreamIDs := make([]string, len(streamIDs))
+	for i, streamID := range streamIDs {
+		resolvedStreamIDs[i] = resolveStreamID(streamKeys[i], streamID)
+	}
+
+	// block the client with resolved IDs
+	blockXReadClient(conn, streamKeys, resolvedStreamIDs, blockTimeout)
 }
 
 // getXReadResults gets the results for XREAD command (shared between blocking and non-blocking)
@@ -797,7 +803,8 @@ func getXReadResults(streamKeys []string, streamIDs []string) [][]interface{} {
 	var resultStreams [][]interface{}
 
 	for i, key := range streamKeys {
-		startID := streamIDs[i]
+		// resolve special IDs like "$"
+		startID := resolveStreamID(key, streamIDs[i])
 
 		// get the stream
 		value, exists := DB.Load(key)
@@ -864,4 +871,36 @@ func writeXReadResponse(conn net.Conn, resultStreams [][]interface{}) {
 			}
 		}
 	}
+}
+
+// resolveStreamID resolves special stream IDs like "$" to actual IDs
+// "$" means the maximum entry ID currently in the stream
+func resolveStreamID(streamKey, streamID string) string {
+	if streamID != "$" {
+		return streamID
+	}
+
+	// get the stream
+	value, exists := DB.Load(streamKey)
+	if !exists {
+		// if stream doesn't exist, "$" resolves to "0-0" (meaning any new entry will be greater)
+		return "0-0"
+	}
+
+	streamEntry, ok := value.(StreamEntry)
+	if !ok || len(streamEntry.entries) == 0 {
+		// if stream is empty, "$" resolves to "0-0"
+		return "0-0"
+	}
+
+	// find the maximum entry ID in the stream
+	maxID := streamEntry.entries[0].id
+	for _, entry := range streamEntry.entries[1:] {
+		comp, err := compareEntryIDs(entry.id, maxID)
+		if err == nil && comp > 0 {
+			maxID = entry.id
+		}
+	}
+
+	return maxID
 }

--- a/app/commands.go
+++ b/app/commands.go
@@ -514,13 +514,13 @@ func handleXAdd(args []string, conn net.Conn) {
 	key := args[1]
 	entryID := args[2]
 
-	// Check if we have an even number of field-value pairs
+	// check if we have an even number of field-value pairs
 	if (len(args)-3)%2 != 0 {
 		writeError(conn, "wrong number of arguments for 'xadd' command")
 		return
 	}
 
-	// Parse field-value pairs
+	// parse field-value pairs
 	data := make(map[string]string)
 	for i := 3; i < len(args); i += 2 {
 		field := args[i]
@@ -569,23 +569,26 @@ func handleXAdd(args []string, conn net.Conn) {
 		entryID = fmt.Sprintf("%d-%d", timestamp, sequence)
 	}
 
-	// Validate the entry ID
+	// validate the entry ID
 	if err := validateEntryID(entryID, streamEntry); err != nil {
 		writeError(conn, err.Error())
 		return
 	}
 
-	// Create new stream entry data
+	// create new stream entry data
 	newEntry := StreamEntryData{
 		id:   entryID,
 		data: data,
 	}
 
-	// Add the entry to the stream
+	// add the entry to the stream
 	streamEntry.entries = append(streamEntry.entries, newEntry)
 
-	// Store the updated stream
+	// store the updated stream
 	DB.Store(key, streamEntry)
+
+	// notify blocked XREAD clients
+	notifyBlockedXReadClients(key, entryID)
 
 	// Return the entry ID as a bulk string
 	writeBulkString(conn, entryID)
@@ -728,26 +731,45 @@ func handleXRange(args []string, conn net.Conn) {
 
 // handleXRead implements the XREAD command for Redis streams
 func handleXRead(args []string, conn net.Conn) {
-	// XREAD streams key1 id1 [key2 id2 ...]
+	// XREAD [BLOCK timeout] streams key1 id1 [key2 id2 ...]
 	// minimum arguments: XREAD streams key id
 	if len(args) < 4 {
 		writeError(conn, "wrong number of arguments for 'xread' command")
 		return
 	}
 
-	// check if the command starts with "streams"
-	if strings.ToLower(args[1]) != "streams" {
+	var blockTimeout float64 = -1 // -1 means no blocking
+	argIndex := 1
+
+	// check for BLOCK parameter
+	if strings.ToLower(args[argIndex]) == "block" {
+		if len(args) < 6 { // XREAD BLOCK timeout streams key id
+			writeError(conn, "wrong number of arguments for 'xread' command")
+			return
+		}
+		
+		var err error
+		blockTimeout, err = strconv.ParseFloat(args[argIndex+1], 64)
+		if err != nil {
+			writeError(conn, "timeout is not a valid integer")
+			return
+		}
+		
+		argIndex += 2 // skip BLOCK and timeout
+	}
+
+	// check if the next argument is "streams"
+	if strings.ToLower(args[argIndex]) != "streams" {
 		writeError(conn, "wrong arguments for 'xread' command")
 		return
 	}
+	argIndex++ // skip "streams"
 
 	// Parse stream keys and IDs
-	// The format is: XREAD streams key1 key2 ... keyN id1 id2 ... idN
-	// We need to find where keys end and IDs start
-	streamArgs := args[2:] // Remove "XREAD" and "streams"
+	// The format is: XREAD [BLOCK timeout] streams key1 key2 ... keyN id1 id2 ... idN
+	streamArgs := args[argIndex:] // Remove processed arguments
 	
 	// For simplicity, assume equal number of keys and IDs
-	// In the base case, we have: key id
 	if len(streamArgs)%2 != 0 {
 		writeError(conn, "wrong number of arguments for 'xread' command")
 		return
@@ -757,11 +779,24 @@ func handleXRead(args []string, conn net.Conn) {
 	streamKeys := streamArgs[:numStreams]
 	streamIDs := streamArgs[numStreams:]
 
-	// result array - each element is [stream_key, [[entry_id, [field1, value1, ...]], ...]]
+	// first, try to get entries immediately (non-blocking check)
+	resultStreams := getXReadResults(streamKeys, streamIDs)
+	
+	// if we have results or not blocking, return immediately
+	if len(resultStreams) > 0 || blockTimeout < 0 {
+		writeXReadResponse(conn, resultStreams)
+		return
+	}
+
+	// no results and blocking requested - block the client
+	blockXReadClient(conn, streamKeys, streamIDs, blockTimeout)
+}
+
+// getXReadResults gets the results for XREAD command (shared between blocking and non-blocking)
+func getXReadResults(streamKeys []string, streamIDs []string) [][]interface{} {
 	var resultStreams [][]interface{}
 
-	for i := 0; i < numStreams; i++ {
-		key := streamKeys[i]
+	for i, key := range streamKeys {
 		startID := streamIDs[i]
 
 		// get the stream
@@ -773,8 +808,7 @@ func handleXRead(args []string, conn net.Conn) {
 
 		streamEntry, ok := value.(StreamEntry)
 		if !ok {
-			writeError(conn, "WRONGTYPE Operation against a key holding the wrong kind of value")
-			return
+			continue
 		}
 
 		// find entries with ID greater than startID (exclusive)
@@ -782,8 +816,7 @@ func handleXRead(args []string, conn net.Conn) {
 		for _, entry := range streamEntry.entries {
 			comp, err := compareEntryIDs(entry.id, startID)
 			if err != nil {
-				writeError(conn, "invalid entry ID format")
-				return
+				continue
 			}
 			// include only entries with ID > startID (comp > 0)
 			if comp > 0 {
@@ -798,6 +831,11 @@ func handleXRead(args []string, conn net.Conn) {
 		}
 	}
 
+	return resultStreams
+}
+
+// writeXReadResponse writes the XREAD response to the connection
+func writeXReadResponse(conn net.Conn, resultStreams [][]interface{}) {
 	// write the result as a RESP array
 	writeArrayHeader(conn, len(resultStreams))
 	for _, streamResult := range resultStreams {

--- a/app/commands.go
+++ b/app/commands.go
@@ -23,6 +23,7 @@ var commandHandlers = map[string]CommandHandler{
 	"BLPOP":  handleBLPop,
 	"XADD":   handleXAdd,
 	"XRANGE": handleXRange,
+	"XREAD":  handleXRead,
 }
 
 // Command handlers
@@ -658,24 +659,47 @@ func handleXRange(args []string, conn net.Conn) {
 		return
 	}
 
-	// normalize the start and end IDs (add sequence numbers if missing)
-	startID = normalizeEntryID(startID, false)
-	endID = normalizeEntryID(endID, true)
+	// handle special case for "-" start ID
+	useMinStart := (startID == "-")
+	
+	// handle special case for "+" end ID
+	useMaxEnd := (endID == "+")
+	
+	// normalize the start and end IDs to add sequence numbers if missing
+	if !useMinStart {
+		startID = normalizeEntryID(startID, false)
+	}
+	if !useMaxEnd {
+		endID = normalizeEntryID(endID, true)
+	}
 
 	// find entries within the range
 	var result []StreamEntryData
 	for _, entry := range streamEntry.entries {
 		// check if entry is within range
-		startComp, err := compareEntryIDs(entry.id, startID)
-		if err != nil {
-			writeError(conn, "invalid start entry ID format")
-			return
+		var startComp int
+		var err error
+		
+		if useMinStart {
+			// when start is "-", all entries satisfy the start condition
+			startComp = 1 // entry.id >= start (since start is effectively minimum)
+		} else {
+			startComp, err = compareEntryIDs(entry.id, startID)
+			if err != nil {
+				writeError(conn, "invalid start entry ID format")
+				return
+			}
 		}
 
 		endComp, err := compareEntryIDs(entry.id, endID)
-		if err != nil {
+		if err != nil && !useMaxEnd {
 			writeError(conn, "invalid end entry ID format")
 			return
+		}
+
+		// when using "+", all entries satisfy the end condition
+		if useMaxEnd {
+			endComp = -1 // entry.id <= end (since end is effectively maximum)
 		}
 
 		// include entry if: entry.id >= startID AND entry.id <= endID
@@ -698,6 +722,108 @@ func handleXRange(args []string, conn net.Conn) {
 		for field, value := range entry.data {
 			writeBulkString(conn, field)
 			writeBulkString(conn, value)
+		}
+	}
+}
+
+// handleXRead implements the XREAD command for Redis streams
+func handleXRead(args []string, conn net.Conn) {
+	// XREAD streams key1 id1 [key2 id2 ...]
+	// minimum arguments: XREAD streams key id
+	if len(args) < 4 {
+		writeError(conn, "wrong number of arguments for 'xread' command")
+		return
+	}
+
+	// check if the command starts with "streams"
+	if strings.ToLower(args[1]) != "streams" {
+		writeError(conn, "wrong arguments for 'xread' command")
+		return
+	}
+
+	// Parse stream keys and IDs
+	// The format is: XREAD streams key1 key2 ... keyN id1 id2 ... idN
+	// We need to find where keys end and IDs start
+	streamArgs := args[2:] // Remove "XREAD" and "streams"
+	
+	// For simplicity, assume equal number of keys and IDs
+	// In the base case, we have: key id
+	if len(streamArgs)%2 != 0 {
+		writeError(conn, "wrong number of arguments for 'xread' command")
+		return
+	}
+
+	numStreams := len(streamArgs) / 2
+	streamKeys := streamArgs[:numStreams]
+	streamIDs := streamArgs[numStreams:]
+
+	// result array - each element is [stream_key, [[entry_id, [field1, value1, ...]], ...]]
+	var resultStreams [][]interface{}
+
+	for i := 0; i < numStreams; i++ {
+		key := streamKeys[i]
+		startID := streamIDs[i]
+
+		// get the stream
+		value, exists := DB.Load(key)
+		if !exists {
+			// stream doesn't exist, skip this stream
+			continue
+		}
+
+		streamEntry, ok := value.(StreamEntry)
+		if !ok {
+			writeError(conn, "WRONGTYPE Operation against a key holding the wrong kind of value")
+			return
+		}
+
+		// find entries with ID greater than startID (exclusive)
+		var entries []StreamEntryData
+		for _, entry := range streamEntry.entries {
+			comp, err := compareEntryIDs(entry.id, startID)
+			if err != nil {
+				writeError(conn, "invalid entry ID format")
+				return
+			}
+			// include only entries with ID > startID (comp > 0)
+			if comp > 0 {
+				entries = append(entries, entry)
+			}
+		}
+
+		// only include this stream in the result if it has entries
+		if len(entries) > 0 {
+			streamResult := []interface{}{key, entries}
+			resultStreams = append(resultStreams, streamResult)
+		}
+	}
+
+	// write the result as a RESP array
+	writeArrayHeader(conn, len(resultStreams))
+	for _, streamResult := range resultStreams {
+		// each stream result is [stream_key, [entries...]]
+		writeArrayHeader(conn, 2)
+		
+		// write stream key
+		writeBulkString(conn, streamResult[0].(string))
+
+		// write entries array
+		entries := streamResult[1].([]StreamEntryData)
+		writeArrayHeader(conn, len(entries))
+		
+		for _, entry := range entries {
+			// each entry is [entry_id, [field1, value1, field2, value2, ...]]
+			writeArrayHeader(conn, 2)
+			
+			// write entry ID
+			writeBulkString(conn, entry.id)
+
+			// write entry data as flat array
+			writeArrayHeader(conn, len(entry.data)*2)
+			for field, value := range entry.data {
+				writeBulkString(conn, field)
+				writeBulkString(conn, value)
+			}
 		}
 	}
 }

--- a/app/database.go
+++ b/app/database.go
@@ -12,6 +12,10 @@ var DB sync.Map
 var blockedClients = make(map[string][]*BlockedClient)
 var blockedClientsMutex sync.RWMutex
 
+// blockedXReadClients stores clients blocked on XREAD, organized by stream key
+var blockedXReadClients = make(map[string][]*BlockedXReadClient)
+var blockedXReadClientsMutex sync.RWMutex
+
 // InitDB initializes the database
 func InitDB() {
 	DB = sync.Map{}
@@ -60,8 +64,8 @@ func blockClient(conn net.Conn, listKey string, timeout float64) {
 			case <-client.done:
 				// element became available
 			case <-time.After(timeoutDuration):
-				// timeout reached, send null response
-				writeNullBulkString(conn)
+				// timeout reached, send null array response
+				writeNullArray(conn)
 			}
 		}
 	}()
@@ -114,4 +118,183 @@ func notifyBlockedClients(listKey string) {
 
 	// signal the client to stop blocking
 	close(client.done)
+}
+
+// blockXReadClient blocks a client waiting for new entries in streams
+func blockXReadClient(conn net.Conn, streamKeys []string, streamIDs []string, timeout float64) {
+	client := &BlockedXReadClient{
+		conn:       conn,
+		streamKeys: streamKeys,
+		streamIDs:  streamIDs,
+		timeout:    timeout,
+		startTime:  time.Now(),
+		done:       make(chan struct{}),
+	}
+
+	// add client to blocked clients list for each stream key
+	blockedXReadClientsMutex.Lock()
+	for _, key := range streamKeys {
+		blockedXReadClients[key] = append(blockedXReadClients[key], client)
+	}
+	blockedXReadClientsMutex.Unlock()
+
+	// start a goroutine to handle the blocking
+	go func() {
+		defer func() {
+			// remove client from blocked clients when done
+			blockedXReadClientsMutex.Lock()
+			for _, key := range streamKeys {
+				clients := blockedXReadClients[key]
+				for i, c := range clients {
+					if c == client {
+						blockedXReadClients[key] = append(clients[:i], clients[i+1:]...)
+						if len(blockedXReadClients[key]) == 0 {
+							delete(blockedXReadClients, key)
+						}
+						break
+					}
+				}
+			}
+			blockedXReadClientsMutex.Unlock()
+		}()
+
+		if timeout == 0 {
+			// block indefinitely
+			<-client.done
+		} else {
+			// block with timeout
+			timeoutDuration := time.Duration(timeout * float64(time.Millisecond)) // timeout is in milliseconds for XREAD
+			select {
+			case <-client.done:
+				// new entry became available
+			case <-time.After(timeoutDuration):
+				// timeout reached, send null array response
+				writeNullArray(conn)
+			}
+		}
+	}()
+}
+
+// notifyBlockedXReadClients checks if there are blocked XREAD clients waiting for the given stream key
+// and notifies all clients that might be interested in the new entry
+func notifyBlockedXReadClients(streamKey string, newEntryID string) {
+	blockedXReadClientsMutex.Lock()
+	defer blockedXReadClientsMutex.Unlock()
+
+	clients, exists := blockedXReadClients[streamKey]
+	if !exists || len(clients) == 0 {
+		return
+	}
+
+	// check each blocked client to see if they should be notified
+	for i := len(clients) - 1; i >= 0; i-- {
+		client := clients[i]
+		
+		// find the stream key index to get the corresponding start ID
+		var startID string
+		for j, key := range client.streamKeys {
+			if key == streamKey {
+				startID = client.streamIDs[j]
+				break
+			}
+		}
+
+		// check if the new entry ID is greater than the client's start ID
+		comp, err := compareEntryIDs(newEntryID, startID)
+		if err != nil {
+			continue
+		}
+
+		if comp > 0 {
+			// notify this client by processing their XREAD request
+			processBlockedXReadClient(client)
+			
+			// remove this client from blocked clients for all streams
+			for _, key := range client.streamKeys {
+				keyClients := blockedXReadClients[key]
+				for k, c := range keyClients {
+					if c == client {
+						blockedXReadClients[key] = append(keyClients[:k], keyClients[k+1:]...)
+						if len(blockedXReadClients[key]) == 0 {
+							delete(blockedXReadClients, key)
+						}
+						break
+					}
+				}
+			}
+			
+			// signal the client to stop blocking
+			close(client.done)
+		}
+	}
+}
+
+// processBlockedXReadClient processes the XREAD request for a blocked client
+func processBlockedXReadClient(client *BlockedXReadClient) {
+	// result array - each element is [stream_key, [[entry_id, [field1, value1, ...]], ...]]
+	var resultStreams [][]interface{}
+
+	for i, key := range client.streamKeys {
+		startID := client.streamIDs[i]
+
+		// get the stream
+		value, exists := DB.Load(key)
+		if !exists {
+			// stream doesn't exist, skip this stream
+			continue
+		}
+
+		streamEntry, ok := value.(StreamEntry)
+		if !ok {
+			continue
+		}
+
+		// find entries with ID greater than startID (exclusive)
+		var entries []StreamEntryData
+		for _, entry := range streamEntry.entries {
+			comp, err := compareEntryIDs(entry.id, startID)
+			if err != nil {
+				continue
+			}
+			// include only entries with ID > startID (comp > 0)
+			if comp > 0 {
+				entries = append(entries, entry)
+			}
+		}
+
+		// only include this stream in the result if it has entries
+		if len(entries) > 0 {
+			streamResult := []interface{}{key, entries}
+			resultStreams = append(resultStreams, streamResult)
+		}
+	}
+
+	// write the result as a RESP array
+	writeArrayHeader(client.conn, len(resultStreams))
+	for _, streamResult := range resultStreams {
+		// each stream result is [stream_key, [entries...]]
+		writeArrayHeader(client.conn, 2)
+		
+		// write stream key
+		writeBulkString(client.conn, streamResult[0].(string))
+
+		// write entries array
+		entries := streamResult[1].([]StreamEntryData)
+		writeArrayHeader(client.conn, len(entries))
+		
+		for _, entry := range entries {
+			// each entry is [entry_id, [field1, value1, field2, value2, ...]]
+			writeArrayHeader(client.conn, 2)
+			
+			// write entry ID
+			writeBulkString(client.conn, entry.id)
+
+			// write entry data as flat array
+			writeArrayHeader(client.conn, len(entry.data)*2)
+			for field, value := range entry.data {
+				writeBulkString(client.conn, field)
+				writeBulkString(client.conn, value)
+			}
+		}
+	}
 }

--- a/app/types.go
+++ b/app/types.go
@@ -39,5 +39,15 @@ type BlockedClient struct {
 	done      chan struct{} // channel to signal when client should stop blocking
 }
 
+// BlockedXReadClient represents a client blocked on XREAD
+type BlockedXReadClient struct {
+	conn       net.Conn
+	streamKeys []string
+	streamIDs  []string
+	timeout    float64
+	startTime  time.Time
+	done       chan struct{} // channel to signal when client should stop blocking
+}
+
 // CommandHandler defines the signature for all command handler functions
 type CommandHandler func(args []string, conn net.Conn)


### PR DESCRIPTION
This pull request adds support for the Redis `XREAD` command, including both non-blocking and blocking behavior for streams, and refines the handling of stream commands. The changes include the implementation of the `XREAD` command handler, infrastructure for managing blocked clients waiting on streams, and improvements to the `XRANGE` command for special ID handling.

**Stream command enhancements:**

* Implemented the `XREAD` command, including argument parsing, support for the `BLOCK` option, and proper RESP array responses. This allows clients to read new entries from streams, optionally blocking until new data arrives.
* Improved the `XRANGE` command to correctly handle special start and end IDs (`"-"` and `"+"`), ensuring proper range queries for streams.

**Blocking client infrastructure:**

* Added the `BlockedXReadClient` type and supporting data structures to manage clients blocked on `XREAD`, including thread-safe maps for tracking blocked clients per stream key.
* Implemented functions to block clients on `XREAD` (`blockXReadClient`), notify them when new entries are available (`notifyBlockedXReadClients`), and process their requests when unblocked.
* Updated the blocking logic for list clients to send a null array response on timeout, aligning with RESP protocol expectations.

**Command handler improvements:**

* Modified `handleXAdd` to notify blocked `XREAD` clients when new entries are added to a stream, ensuring timely delivery of new data to waiting clients.

These changes collectively provide robust support for Redis stream reading and blocking semantics, improving compatibility and client experience with stream operations.